### PR TITLE
Add calculation history feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Calculadora de Gastos Compartidos
+
+Esta es una sencilla aplicación web para calcular y dividir gastos compartidos entre dos personas, Alejandro y Lucila.
+
+La aplicación permite a los usuarios ingresar los gastos individuales de cada persona y luego calcular cuánto debe cada uno al otro para equilibrar las cuentas. Es una herramienta útil para parejas, amigos o compañeros de piso que necesiten llevar un registro de sus gastos compartidos.
+
+El idioma de la aplicación es español.

--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
     <button onclick="calcularDiferencia()">Calcular</button>
     <div id="resultado"></div>
 
+    <h2>Historial de Cálculos</h2>
+    <button id="limpiarHistorialBtn" onclick="limpiarHistorial()">Limpiar Historial</button>
+    <div id="historialCalculos">
+        <!-- El historial se cargará aquí por JavaScript -->
+    </div>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -25,5 +25,110 @@ function calcularDiferencia() {
     }
 
     explicacion += '</ul>';
+
+    // Guardar en localStorage
+    const entradaHistorial = {
+        alejandro: misGastos, // misGastos es un número
+        lucila: gastosCompanera, // gastosCompanera es un número
+        mensaje: resultado, // resultado es un string
+        timestamp: new Date().toISOString()
+    };
+    agregarAlHistorial(entradaHistorial);
+
     document.getElementById('resultado').innerHTML = `<strong>${resultado}</strong><br>${explicacion}`;
+}
+
+function agregarAlHistorial(entradaHistorial) {
+    const HISTORIAL_KEY = 'historialGastosClochu';
+    let historial = [];
+    try {
+        const historialGuardado = localStorage.getItem(HISTORIAL_KEY);
+        if (historialGuardado) {
+            historial = JSON.parse(historialGuardado);
+        }
+    } catch (e) {
+        console.error("Error al parsear historial de localStorage:", e);
+        historial = []; // Empezar con un array vacío si hay error
+    }
+
+    historial.push(entradaHistorial);
+
+    try {
+        localStorage.setItem(HISTORIAL_KEY, JSON.stringify(historial));
+    } catch (e) {
+        console.error("Error al guardar historial en localStorage:", e);
+    }
+    cargarYMostrarHistorial(); // Actualizar la vista del historial
+}
+
+function cargarYMostrarHistorial() {
+    const HISTORIAL_KEY = 'historialGastosClochu';
+    const historialDiv = document.getElementById('historialCalculos');
+
+    if (!historialDiv) {
+        console.error("Elemento con ID 'historialCalculos' no encontrado.");
+        return;
+    }
+
+    let historial = [];
+    try {
+        const historialGuardado = localStorage.getItem(HISTORIAL_KEY);
+        if (historialGuardado) {
+            historial = JSON.parse(historialGuardado);
+        }
+    } catch (e) {
+        console.error("Error al parsear historial de localStorage:", e);
+        historialDiv.innerHTML = '<p>Error al cargar el historial.</p>';
+        return;
+    }
+
+    historialDiv.innerHTML = ''; // Limpiar contenido anterior
+
+    if (historial.length === 0) {
+        historialDiv.innerHTML = '<p>No hay historial de cálculos.</p>';
+        return;
+    }
+
+    const ul = document.createElement('ul');
+    // Iterar en orden inverso para mostrar el más nuevo primero
+    for (let i = historial.length - 1; i >= 0; i--) {
+        const entrada = historial[i];
+        const li = document.createElement('li');
+        
+        const fecha = new Date(entrada.timestamp).toLocaleString('es-ES', { 
+            day: 'numeric', month: 'long', year: 'numeric', 
+            hour: '2-digit', minute: '2-digit' 
+        });
+
+        const alejandroGasto = (typeof entrada.alejandro === 'number') ? entrada.alejandro.toLocaleString('en-US', {style: 'currency', currency: 'USD'}) : 'N/A';
+        const lucilaGasto = (typeof entrada.lucila === 'number') ? entrada.lucila.toLocaleString('en-US', {style: 'currency', currency: 'USD'}) : 'N/A';
+
+        li.innerHTML = `
+            <strong>Fecha:</strong> ${fecha}<br>
+            <strong>Alejandro:</strong> ${alejandroGasto} | 
+            <strong>Lucila:</strong> ${lucilaGasto}<br>
+            <strong>Resultado:</strong> ${entrada.mensaje}
+        `;
+        ul.appendChild(li);
+    }
+    historialDiv.appendChild(ul);
+}
+
+// Cargar historial cuando el DOM esté completamente cargado
+document.addEventListener('DOMContentLoaded', cargarYMostrarHistorial);
+
+function limpiarHistorial() {
+    const HISTORIAL_KEY = 'historialGastosClochu';
+    if (confirm('¿Estás seguro de que deseas borrar todo el historial? Esta acción no se puede deshacer.')) {
+        try {
+            localStorage.removeItem(HISTORIAL_KEY);
+            console.log('Historial borrado de localStorage.');
+        } catch (e) {
+            console.error("Error al borrar el historial de localStorage:", e);
+            // Opcionalmente, mostrar un mensaje de error al usuario
+            alert('Error al intentar borrar el historial.');
+            return; // No continuar si hay error
+        }
+        cargarYMostrarHistorial(); // Actualizar la vista del historial
+    }
 }

--- a/styles.css
+++ b/styles.css
@@ -40,7 +40,7 @@ button:hover {
     background-color: #555555; /* Lighter on hover */
     transform: scale(1.05);
 }
-}
+/* } This closing brace was likely a typo, removing it. */
 
 label {
     color: #BDBDBD; /* Grey text for labels */
@@ -72,4 +72,77 @@ div {
     .input-container {
         flex-direction: column;
     }
+}
+
+/* Styling for H2 headings */
+h2 {
+    color: #E0E0E0; /* Light text, consistent with body */
+    font-family: 'Montserrat', sans-serif;
+    margin-top: 30px;
+    margin-bottom: 15px;
+}
+
+/* Styling for the History Section */
+#historialCalculos {
+    margin-top: 10px;
+    padding: 10px;
+    background-color: #1c1c1c; /* Slightly lighter than body background */
+    border-radius: 5px;
+}
+
+#historialCalculos ul {
+    list-style-type: none;
+    padding-left: 0;
+    margin: 0;
+}
+
+#historialCalculos li {
+    font-family: 'Montserrat', sans-serif;
+    background-color: #282828; /* Darker than #historialCalculos background, lighter than body */
+    border: 1px solid #333333;
+    border-radius: 4px;
+    padding: 15px;
+    margin-bottom: 10px;
+    color: #E0E0E0; /* Light text */
+    font-size: 0.9em;
+    line-height: 1.6;
+}
+
+#historialCalculos li strong {
+    color: #F09E56; /* Accent color for emphasis */
+}
+
+/* Styling for the "No hay historial..." message if it's a paragraph */
+#historialCalculos p {
+    font-family: 'Montserrat', sans-serif;
+    color: #BDBDBD; /* Grey text, similar to labels */
+    padding: 10px;
+    text-align: center;
+}
+
+/* Styling for the Clear History Button */
+#limpiarHistorialBtn {
+    font-family: 'Montserrat', sans-serif;
+    padding: 10px 15px; /* Adjusted padding */
+    background: #7D3C3C; /* Dark red/maroon for destructive action */
+    border: none;
+    color: #FFFFFF; /* White text */
+    border-radius: 5px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    cursor: pointer;
+    transition: background-color 0.3s, transform 0.2s;
+    font-weight: bold;
+    font-size: 14px; /* Slightly smaller or same as other button */
+    margin-top: 0px; /* Align with h2 or adjust as needed */
+    margin-bottom: 10px; /* Space before the history list */
+}
+
+#limpiarHistorialBtn:hover {
+    background-color: #994A4A; /* Lighter red on hover */
+    transform: scale(1.03);
+}
+
+#limpiarHistorialBtn:active {
+    background-color: #6B2F2F; /* Darker red on active/click */
+    transform: scale(0.98);
 }


### PR DESCRIPTION
This commit introduces a calculation history feature to the application.

Key changes:
- Calculations (Alejandro's expense, Lucila's expense, result message, and timestamp) are now saved to localStorage.
- A new section "Historial de Cálculos" is added to index.html to display past calculations.
- script.js is updated to load history from localStorage on page load and display it.
- The history display is updated dynamically after each new calculation.
- A "Limpiar Historial" button allows you to clear all saved calculations from localStorage, with a confirmation prompt.
- The new UI elements (history section, list items, clear button) are styled to match the application's dark theme.
- Corrected a minor CSS syntax error in styles.css.